### PR TITLE
Support HTTP Bearer Auth

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
 
     <groupId>se.thinkware.gocd</groupId>
     <artifactId>docker-poller-plugin</artifactId>
-    <version>1.1.0</version>
+    <version>1.2.0-PRE</version>
 
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>

--- a/resources/plugin.xml
+++ b/resources/plugin.xml
@@ -2,7 +2,7 @@
 <go-plugin id="docker-registry" version="1">
     <about>
         <name>dockerpoller</name>
-        <version>1.1.0</version>
+        <version>1.2.0-PRE</version>
         <target-go-version>17.7.0</target-go-version>
         <description>Docker package poller plugin for Thoughworks GoCD.</description>
         <vendor>

--- a/resources/plugin.xml
+++ b/resources/plugin.xml
@@ -9,8 +9,5 @@
             <name>Magnus Lyckå</name>
             <url></url>
         </vendor>
-        <target-os>
-            <value>Linux</value>
-        </target-os>
     </about>
 </go-plugin>


### PR DESCRIPTION
This PR adds support for HTTP Bearer (Anonymous Token) Auth following the Docker spec:

https://docs.docker.com/registry/spec/auth/token/

This was required to work with an Artifactory docker registry.